### PR TITLE
Minor performance improvements for RBF evaluation

### DIFF
--- a/ferreus_bbfmm/src/linear_tree.rs
+++ b/ferreus_bbfmm/src/linear_tree.rs
@@ -495,7 +495,7 @@ pub fn points_to_keys(
     let side_length = morton::get_side_length(radius, depth);
     let displacement: Vec<f64> = center.iter().map(|&c| c - radius).collect();
 
-    let results: Vec<Result<u64, FmmError>> = points
+    points
         .par_row_iter()
         .enumerate()
         .map(|(idx, point)| {
@@ -509,14 +509,7 @@ pub fn points_to_keys(
 
             Ok(current_key)
         })
-        .collect();
-
-    let mut keys = Vec::with_capacity(points.nrows());
-    for r in results {
-        keys.push(r?);
-    }
-
-    Ok(keys)
+        .collect()
 }
 
 pub fn get_points_to_leaves_map(point_keys: &Vec<u64>) -> HashMap<u64, Vec<usize>> {

--- a/ferreus_rbf/src/rbf.rs
+++ b/ferreus_rbf/src/rbf.rs
@@ -1260,11 +1260,16 @@ impl RBFInterpolator {
 /// - Adds polynomial (monomial) contribution if a polynomial basis is enabled.
 #[inline(always)]
 fn _evaluate(evaluator_params: EvaluatorParams) -> Result<(Mat<f64>, Option<Mat<f64>>), FmmError> {
-    let mut eval_points = evaluator_params.target_points.clone().to_owned();
-
-    if let Some(gt) = evaluator_params.global_trend {
-        eval_points = gt.transform_points(evaluator_params.target_points);
-    }
+    // Borrow the targets directly when no global trend is present; only a
+    // trend transform materializes a transformed copy of the points.
+    let transformed_points;
+    let eval_points: MatRef<f64> = match evaluator_params.global_trend {
+        Some(gt) => {
+            transformed_points = gt.transform_points(evaluator_params.target_points);
+            transformed_points.as_mat_ref()
+        }
+        None => evaluator_params.target_points,
+    };
 
     let (mut values, mut gradients) = match (
         evaluator_params.evaluator_mode,
@@ -1273,28 +1278,28 @@ fn _evaluate(evaluator_params: EvaluatorParams) -> Result<(Mat<f64>, Option<Mat<
         (FmmEvaluatorMode::Leaves, false) => (
             evaluator_params.tree.evaluate_leaves(
                 evaluator_params.coefficients.point_coefficients.as_mat_ref(),
-                eval_points.as_mat_ref(),
+                eval_points,
             )?,
             None,
         ),
         (FmmEvaluatorMode::Leaves, true) => {
             let (values, gradients) = evaluator_params.tree.evaluate_leaves_with_gradients(
                 evaluator_params.coefficients.point_coefficients.as_mat_ref(),
-                eval_points.as_mat_ref(),
+                eval_points,
             )?;
             (values, Some(gradients))
         }
         (FmmEvaluatorMode::Full, false) => (
             evaluator_params.tree.evaluate(
                 evaluator_params.coefficients.point_coefficients.as_mat_ref(),
-                eval_points.as_mat_ref(),
+                eval_points,
             )?,
             None,
         ),
         (FmmEvaluatorMode::Full, true) => {
             let (values, gradients) = evaluator_params.tree.evaluate_with_gradients(
                 evaluator_params.coefficients.point_coefficients.as_mat_ref(),
-                eval_points.as_mat_ref(),
+                eval_points,
             )?;
             (values, Some(gradients))
         }


### PR DESCRIPTION
With these minor changes, a few copies are eliminated from the BBFMM RBF evaluation calculations. The result is modest evaluation time improvements (one measurement at ~10%), and more importantly lower peak memory consumption. 

One set of example profile results (magnitudes aren't huge here but we've observed greater related jumps in mem consumption in larger examples):

Before:
<img width="552" height="455" alt="image" src="https://github.com/user-attachments/assets/63fee450-d407-43c5-b709-70e8b739c8e9" />

After (note the final spike is eliminated):
<img width="685" height="479" alt="image" src="https://github.com/user-attachments/assets/71c344c1-2d1e-4793-bfaa-0c870ba44afb" />

As a bonus, I've actually remembered DSO for once! 😬 