### PR TITLE
Performance improvements for dense BBFMM RBF evaluation

### DIFF
--- a/ferreus_bbfmm/src/bbfmm.rs
+++ b/ferreus_bbfmm/src/bbfmm.rs
@@ -1118,9 +1118,18 @@ impl<K: KernelFunction + Send + Sync> FmmTree<K> {
         target_values_ref: MatRef<f64>,
         target_gradients_ref: Option<MatRef<f64>>,
     ) {
-        self.tree_lists
+        // Chunk evaluate per leaf
+        let chunk_size = self.eval_chunk_size.max(1);
+        let work_items: Vec<(&u64, &[usize])> = self
+            .tree_lists
             .leaf_target_indices
-            .par_iter()
+            .iter()
+            .flat_map(|(leaf, indices)| {
+                indices.chunks(chunk_size).map(move |chunk| (leaf, chunk))
+            })
+            .collect();
+        work_items
+            .into_par_iter()
             .for_each(|(leaf, leaf_target_indices)| {
                 if let Some(u_list) = self.tree_lists.u_lists.get(leaf) {
                     if !u_list.is_empty() {

--- a/ferreus_bbfmm/src/bbfmm.rs
+++ b/ferreus_bbfmm/src/bbfmm.rs
@@ -382,6 +382,8 @@ impl<K: KernelFunction + Send + Sync> FmmTree<K> {
     /// * `weights`: Matrix of shape (N, K), where N is the number of source points and K is the number of right-hand sides
     ///              to evaluate, containing source point weights (values)
     pub fn set_weights(&mut self, weights: MatRef<f64>) {
+        self.assert_upward_state_retained("set_weights");
+
         self.nrhs = weights.ncols();
         self.reset_multipole_coefficients();
 
@@ -447,6 +449,8 @@ impl<K: KernelFunction + Send + Sync> FmmTree<K> {
         weights: MatRef<f64>,
         target_points: MatRef<f64>,
     ) -> Result<(Mat<f64>, Option<Mat<f64>>), FmmError> {
+        self.assert_upward_state_retained("evaluate");
+
         self.reset_local_coefficients();
 
         let ntarget_points = target_points.shape().0;
@@ -517,11 +521,35 @@ impl<K: KernelFunction + Send + Sync> FmmTree<K> {
     /// # Returns
     /// * `target_values` : Matrix of shape (M, K), where M is the number of target points and K is the number of right-hand sides evaluated.
     pub fn set_local_coefficients(&mut self, weights: MatRef<f64>) {
+        self.assert_upward_state_retained("set_local_coefficients");
+
         self.reset_local_coefficients();
 
         let full_tree_set: HashSet<u64> = self.tree_lists.tree.iter().cloned().collect();
 
         self.downward_pass(&weights, &full_tree_set);
+    }
+
+    /// Releases the tree state that is only read by the upward and downward passes, keeping just
+    /// what [`FmmTree::evaluate_leaves`] and [`FmmTree::evaluate_leaves_with_gradients`] need.
+    pub fn release_upward_state(&mut self) {
+        if !self.adaptive_tree {
+            self.multipole_coefficients = Mat::<f64>::new();
+        }
+
+        self.tree_lists.v_lists = HashMap::default();
+        self.tree_lists.x_lists = None;
+        self.tree_lists.children = HashMap::default();
+        self.tree_lists.level_cells_map = HashMap::default();
+    }
+
+    /// Panics if [`FmmTree::release_upward_state`] has already run.
+    fn assert_upward_state_retained(&self, method: &str) {
+        assert!(
+            !self.tree_lists.level_cells_map.is_empty(),
+            "`{method}` is unavailable after `release_upward_state`; the tree only supports leaf \
+             evaluation passes"
+        );
     }
 
     /// Performs a leaf evaluation pass to calculate the values at the target locations. Intended to be
@@ -1453,7 +1481,7 @@ impl<K: KernelFunction + Send + Sync> FmmTree<K> {
 #[cfg(test)]
 mod tests {
     use super::{FmmError, FmmTree, KernelFunction};
-    use faer::{RowRef, mat};
+    use faer::{RowRef, mat, Mat};
     use std::sync::Arc;
 
     struct TestKernel;
@@ -1508,5 +1536,86 @@ mod tests {
             }
             other => panic!("Expected PointOutsideTree error, got {:?}", other),
         }
+    }
+
+    /// Deterministic pseudo-random points in the unit cube, clustered towards one corner so the
+    /// uniform tree has many more cells than the adaptive tree.
+    fn clustered_points(n: usize) -> Mat<f64> {
+        let modulus = 2_147_483_647_u64;
+        let mut state = 1_u64;
+        let mut next_coordinate = || {
+            state = (state * 48_271) % modulus;
+            (state as f64 / modulus as f64).powi(3)
+        };
+
+        Mat::from_fn(n, 3, |_, _| next_coordinate())
+    }
+
+    /// Releasing the upward-pass state must not change what the leaf pass evaluates.
+    fn release_upward_state_preserves_leaf_values(adaptive_tree: bool) {
+        let source_points = Arc::new(clustered_points(2000));
+        let target_points = Mat::<f64>::from_fn(500, 3, |i, j| ((i * 3 + j) % 97) as f64 / 96.0);
+        let weights = Mat::<f64>::from_fn(source_points.nrows(), 1, |i, _| {
+            ((i % 13) as f64 - 6.0) / 6.0
+        });
+
+        let mut tree = FmmTree::new(
+            source_points,
+            4usize,
+            TestKernel,
+            adaptive_tree,
+            false,
+            Some(vec![0.0, 0.0, 0.0, 1.0, 1.0, 1.0]),
+            None,
+        );
+
+        tree.set_weights(weights.as_ref());
+        tree.set_local_coefficients(weights.as_ref());
+
+        let before = tree
+            .evaluate_leaves(weights.as_ref(), target_points.as_ref())
+            .unwrap();
+
+        tree.release_upward_state();
+
+        let after = tree
+            .evaluate_leaves(weights.as_ref(), target_points.as_ref())
+            .unwrap();
+
+        for i in 0..before.nrows() {
+            assert_eq!(before[(i, 0)], after[(i, 0)], "target {i} changed");
+        }
+    }
+
+    #[test]
+    fn release_upward_state_preserves_leaf_values_uniform() {
+        release_upward_state_preserves_leaf_values(false);
+    }
+
+    #[test]
+    fn release_upward_state_preserves_leaf_values_adaptive() {
+        release_upward_state_preserves_leaf_values(true);
+    }
+
+    #[test]
+    #[should_panic(expected = "unavailable after `release_upward_state`")]
+    fn set_weights_panics_after_release_upward_state() {
+        let source_points = Arc::new(clustered_points(500));
+        let weights = Mat::<f64>::from_fn(source_points.nrows(), 1, |_, _| 1.0);
+
+        let mut tree = FmmTree::new(
+            source_points,
+            4usize,
+            TestKernel,
+            false,
+            false,
+            Some(vec![0.0, 0.0, 0.0, 1.0, 1.0, 1.0]),
+            None,
+        );
+
+        tree.set_weights(weights.as_ref());
+        tree.set_local_coefficients(weights.as_ref());
+        tree.release_upward_state();
+        tree.set_weights(weights.as_ref());
     }
 }

--- a/ferreus_rbf/docs/fmm_params.md
+++ b/ferreus_rbf/docs/fmm_params.md
@@ -27,6 +27,7 @@ Orders that are too low may stall solver convergence.
 - `compression_type`: [`FmmCompressionType::ACA`]
 - `epsilon`: `10^(-interpolation_order)`
 - `eval_chunk_size`: `1024`
+- `eval_adaptive`: `true`
 
 # Examples
 ```

--- a/ferreus_rbf/src/config.rs
+++ b/ferreus_rbf/src/config.rs
@@ -222,6 +222,12 @@ pub struct FmmParams {
 
     /// Number of target points to evaluate in each chunk.
     pub eval_chunk_size: usize,
+
+    /// Whether target-evaluation trees use adaptive subdivision. Uniform (`false`)
+    /// is typically faster for dense uniformly distributed target points, but comes 
+    /// at a higher memory cost. 
+    /// Does not affect the solve phase, which always uses an adaptive tree.
+    pub eval_adaptive: bool,
 }
 
 impl From<FmmParams> for ferreus_bbfmm::FmmParams {
@@ -246,6 +252,7 @@ impl FmmParams {
             compression_type: FmmCompressionType::ACA,
             epsilon: 10f64.powi(-(default_interpolation_order as i32)),
             eval_chunk_size: 1024,
+            eval_adaptive: true,
         }
     }
 }

--- a/ferreus_rbf/src/rbf.rs
+++ b/ferreus_rbf/src/rbf.rs
@@ -756,7 +756,7 @@ impl RBFInterpolator {
     /// let values = rbfi.evaluate(targets.as_ref());
     /// ```
     pub fn evaluate(&self, target_points: MatRef<f64>) -> Mat<f64> {
-        let adaptive = true;
+        let adaptive = self.params.fmm_params.eval_adaptive;
         let sparse = false;
 
         let extents = self._get_evaluator_union_extents(Some(target_points), None);
@@ -808,7 +808,7 @@ impl RBFInterpolator {
     /// let (values, gradients) = rbfi.evaluate_with_gradients(targets.as_ref());
     /// ```
     pub fn evaluate_with_gradients(&self, target_points: MatRef<f64>) -> (Mat<f64>, Mat<f64>) {
-        let adaptive = true;
+        let adaptive = self.params.fmm_params.eval_adaptive;
         let sparse = false;
 
         let extents = self._get_evaluator_union_extents(Some(target_points), None);
@@ -910,7 +910,7 @@ impl RBFInterpolator {
     /// rbfi.build_evaluator(None);
     /// ```
     pub fn build_evaluator(&mut self, extents: Option<Vec<f64>>) {
-        let adaptive = true;
+        let adaptive = self.params.fmm_params.eval_adaptive;
         let sparse = false;
 
         let mut tree = self._setup_fmmtree(adaptive, sparse, extents);

--- a/ferreus_rbf/src/rbf.rs
+++ b/ferreus_rbf/src/rbf.rs
@@ -919,6 +919,9 @@ impl RBFInterpolator {
 
         tree.set_local_coefficients(self.coefficients.point_coefficients.as_mat_ref());
 
+        // The stored evaluator only ever runs leaf passes, so the upward/downward pass state can be dropped
+        tree.release_upward_state();
+
         self.evaluator = Some(tree);
     }
 

--- a/ferreus_rbf_utils/src/utils.rs
+++ b/ferreus_rbf_utils/src/utils.rs
@@ -437,6 +437,15 @@ macro_rules! for_each_kernel {
                 }
             }
 
+            /// Releases the state only the upward and downward passes read, leaving the tree
+            /// usable for leaf evaluation passes alone.
+            #[inline]
+            pub fn release_upward_state(&mut self) {
+                match self {
+                    $( Self::$V(t) => t.release_upward_state(), )*
+                }
+            }
+
             /// Evaluates the FMM at the supplied target points.
             #[inline]
             pub fn evaluate(

--- a/py_ferreus_rbf/examples/fmm_eval_adaptive_benchmark.py
+++ b/py_ferreus_rbf/examples/fmm_eval_adaptive_benchmark.py
@@ -1,0 +1,76 @@
+# Temporary example to test dense rbf evaluation performance
+
+import time
+
+import numpy as np
+
+from ferreus_rbf import RBFInterpolator
+from ferreus_rbf.config import FmmCompressionType, FmmParams, Params
+from ferreus_rbf.interpolant_config import InterpolantSettings, RBFKernelType
+
+RADIUS = 5.0
+N_PER_SPHERE = 10_000
+BASE_RANGE = 40.0
+INTERPOLATION_ORDER = 7
+
+rng = np.random.default_rng(0)
+
+
+def sphere_sdf_points(center: np.ndarray, n: int) -> tuple[np.ndarray, np.ndarray]:
+    """Points filling the sphere region, denser near the centre, with signed distances."""
+    directions = rng.normal(size=(n, 3))
+    directions /= np.linalg.norm(directions, axis=1, keepdims=True)
+    radii = rng.uniform(0.0, 1.5 * RADIUS, size=(n, 1))
+    points = center + directions * radii
+    values = np.linalg.norm(points - center, axis=1) - RADIUS
+    return points, values
+
+
+points_a, values_a = sphere_sdf_points(np.array([5.0, 5.0, 5.0]), N_PER_SPHERE)
+points_b, values_b = sphere_sdf_points(np.array([30.0, 30.0, 5.0]), N_PER_SPHERE)
+
+source_points = np.vstack((points_a, points_b))
+source_values = np.concatenate((values_a, values_b))
+
+axis = np.arange(0.0, 40.0 + 0.25, 0.25)
+targets = np.stack(
+    np.meshgrid(axis, axis, axis, indexing="ij"), axis=-1
+).reshape(-1, 3)
+
+interpolant_settings = InterpolantSettings(
+    RBFKernelType.Spheroidal,
+    base_range=BASE_RANGE,
+)
+
+
+def make_params(eval_adaptive: bool) -> Params:
+    fmm_params = FmmParams(
+        interpolation_order=INTERPOLATION_ORDER,
+        max_points_per_cell=256,
+        compression_type=FmmCompressionType.ACA,
+        epsilon=10.0**-INTERPOLATION_ORDER,
+        eval_chunk_size=1024,
+        eval_adaptive=eval_adaptive,
+    )
+    return Params(RBFKernelType.Spheroidal, fmm_params=fmm_params)
+
+
+print(f"Sources: {source_points.shape[0]}  Targets: {targets.shape[0]}")
+
+for eval_adaptive in (True, False):
+    rbfi = RBFInterpolator(
+        source_points,
+        source_values,
+        interpolant_settings,
+        params=make_params(eval_adaptive),
+    )
+
+    start = time.perf_counter()
+    values = rbfi.evaluate(targets)
+    elapsed = time.perf_counter() - start
+
+    print(
+        f"eval_adaptive={str(eval_adaptive):<5} "
+        f"{elapsed:7.3f} s  "
+        f"min={values.min():+.4f} max={values.max():+.4f}"
+    )

--- a/py_ferreus_rbf/ferreus_rbf/config/__init__.pyi
+++ b/py_ferreus_rbf/ferreus_rbf/config/__init__.pyi
@@ -118,7 +118,8 @@ class FmmParams:
     - `max_points_per_cell`: `256`  
     - `compression_type`: [`FmmCompressionType.ACA`][ferreus_rbf.config.FmmCompressionType.ACA]  
     - `epsilon`: `10^(-interpolation_order)`  
-    - `eval_chunk_size`: `1024`  
+    - `eval_chunk_size`: `1024`
+    - `eval_adaptive`: `True`
 
     Parameters
     ----------
@@ -132,6 +133,12 @@ class FmmParams:
         Tolerance threshold for M2L compression.
     eval_chunk_size : int
         Number of target points to evaluate in each chunk.
+    eval_adaptive : bool
+        Whether target-evaluation trees use adaptive subdivision. 
+        Uniform (`false`) is typically faster for dense uniformly 
+        distributed target points, but comes at a higher memory 
+        cost. Does not affect the solve phase, which always uses 
+        an adaptive tree.
     """
     def __init__(
         self,
@@ -140,6 +147,7 @@ class FmmParams:
         compression_type: FmmCompressionType,
         epsilon: float,
         eval_chunk_size: int,
+        eval_adaptive: bool = True,
     ) -> None: ...
 
 class Params:

--- a/py_ferreus_rbf/src/python_bindings.rs
+++ b/py_ferreus_rbf/src/python_bindings.rs
@@ -259,13 +259,14 @@ pub struct FmmParams {
 #[pymethods]
 impl FmmParams {
     #[new]
-    #[pyo3(signature=(interpolation_order, max_points_per_cell, compression_type, epsilon, eval_chunk_size))]
+    #[pyo3(signature=(interpolation_order, max_points_per_cell, compression_type, epsilon, eval_chunk_size, eval_adaptive=true))]
     fn new(
         interpolation_order: usize,
         max_points_per_cell: usize,
         compression_type: FmmCompressionType,
         epsilon: f64,
         eval_chunk_size: usize,
+        eval_adaptive: bool,
     ) -> PyResult<Self> {
         Ok(Self {
             inner: config::FmmParams {
@@ -274,6 +275,7 @@ impl FmmParams {
                 compression_type: compression_type.into(),
                 epsilon,
                 eval_chunk_size,
+                eval_adaptive,
             },
         })
     }


### PR DESCRIPTION
Here are some updates to improve performance of BBFMM RBF evaluation on a dense, regular grid of evaluation points. Like you suggested @graphic-goose, switching to a uniform tree really speeds things up (~**10x speedup** on a few datasets I tested), and more fully utilizes CPU threads. 

Changes made: 
- Added and exposed an `eval_adaptive` arg to allow evaluation on a uniform tree, rather than the default adaptive tree (adaptive based on the source points). Uniform tree is quite a bit faster than adaptive tree and achieves most of the speedup noted above.
- Added chunked evaluation outside of the parallelization, which helps more fully utilize threads on the tail end of computations.
- Updated the RBFInterpolator to release state from the tree that is only needed for the uppass / downpass, after completion. This attached state can be very memory-intensive for the denser uniform tree. 

Another thought is that currently the tree leaf size is based purely on source points and not on target points. I considered bringing in some logic to consider the target point distribution, but it didn't fit very nicely and in my opinion didn't warrant the added complexity. 